### PR TITLE
Signed letter for libGDX

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Signed,
 - John-David Dalton ([@jdalton](https://github.com/jdalton)), maintainer of Lodash
 - Juriy Zaytsev ([@kangax](https://github.com/kangax)), maintainer of Fabric.js
 - Ken Wheeler ([@kenwheeler](https://github.com/kenwheeler)), maintainer of Slick
+- Mario Zechner ([@badlogicgames](https://github.com/badlogic)), maintainer of libGDX
 - Nicholas C. Zakas ([@nzakas](https://github.com/nzakas)), maintainer of ESLint
 - Nicolás Bevacqua ([@bevacqua](https://github.com/bevacqua)), maintainer of `dragula`
 - Pascal Hartig ([@passy](https://github.com/passy)), maintainer of TodoMVC


### PR DESCRIPTION
In the name of all [libGDX](https://github.com/libgdx/libgdx) contributors. We too feel the pain immensely.