### PR TITLE
Remove signatures from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,56 +42,6 @@ very good at that!
 
 Signed,
 
-- Adam Bradley ([@adamdbradley](https://github.com/adamdbradley)), maintainer of Ionic
-- Addy Osmani ([@addyosmani](https://github.com/addyosmani)), maintainer of TodoMVC
-- Andreas Tolfsen ([@andreastt](https://github.com/andreastt)), maintainer of Selenium
-- Andrew Sampson ([@codeusa](https://github.com/codeusa)), maintainer of Borderless-Gaming
-- Ariya Hidayat ([@ariya](https://github.com/ariya)), maintainer of PhantomJS
-- Ashley Williams ([@ashleygwilliams](https://github.com/ashleygwilliams)), Developer Community Manager, npm
-- Ben Briggs ([@ben-eb](https://github.com/ben-eb)), maintainer of PostCSS
-- Cătălin Mariș ([@alrra](https://github.com/alrra)), maintainer of HTML5 Boilerplate
-- Christopher Chedeau ([@vjeux](https://github.com/vjeux)), maintainer of React Native
-- Dan Abramov ([@gaearon](http://github.com/gaearon)), maintainer of Redux
-- Dave Methvin ([@dmethvin](https://github.com/dmethvin)), maintainer of jQuery
-- Daniel Rosenwasser ([@drosenwasser](https://github.com/DanielRosenwasser)), maintainer of TypeScript
-- Didier Baquier ([@dbaq](https://github.com/dbaq)), maintainer of Cordova SMS
-- Domenic Denicola ([@domenic](https://github.com/domenic)), maintainer of WHATWG Standards
-- Dylan Schiemann ([@dylans](http://github.com/dylans)), maintainer of Dojo Toolkit
-- Feross Aboukhadijeh ([@feross](https://github.com/feross)), maintainer of WebTorrent
-- Forbes Lindesay ([@ForbesLindesay](https://github.com/ForbesLindesay)) maintainer of Pug (formerly known as Jade)
-- Henry Zhu ([@hzoo](https://github.com/hzoo)), maintainer of JSCS
-- Jack Humbert ([@jackhumbert](https://github.com/jackhumbert)), maintainer of QMK Firmware
-- James Kyle ([@thejameskyle](https://github.com/thejameskyle)), maintainer of Babel
-- Jaydson Gomes ([@jaydson](https://github.com/jaydson)), maintainer of HarmonicJS
-- Jesus Rodriguez ([@foxandxss](https://github.com/Foxandxss/)), maintainer of ui-bootstrap
-- John-David Dalton ([@jdalton](https://github.com/jdalton)), maintainer of Lodash
-- Juriy Zaytsev ([@kangax](https://github.com/kangax)), maintainer of Fabric.js
-- Ken Wheeler ([@kenwheeler](https://github.com/kenwheeler)), maintainer of Slick
-- Kent C. Dodds ([@kentcdodds](https://github.com/kentcdodds)), maintainer of angular-formly
-- Mario Zechner ([@badlogicgames](https://github.com/badlogic)), maintainer of libGDX
-- Matthew McClure ([@mmcc](https://github.com/mmcc)), a maintainer of Video.js
-- Merrick Christensen ([@iammerrick](https://github.com/iammerrick)), maintainer of Squire.js
-- Nicholas C. Zakas ([@nzakas](https://github.com/nzakas)), maintainer of ESLint
-- Nicolás Bevacqua ([@bevacqua](https://github.com/bevacqua)), maintainer of `dragula`
-- Nikita Putsenko ([@nlutsenko](https://github.com/nlutsenko)), maintainer of Bolts.framework, Parse SDK
-- Pascal Hartig ([@passy](https://github.com/passy)), maintainer of TodoMVC
-- Paul Miller ([@paulmillr](https://github.com/paulmillr)), maintainer of Brunch
-- Rashiq Ahmad ([@rashiq](https://github.com/rashiq)), a maintainer of Kiwix
-- Ricardo Cabello ([@mrdoob](https://github.com/mrdoob)), maintainer of three.js
-- Ryan Cavanaugh ([@searyanc](https://github.com/RyanCavanaugh)), maintainer of TypeScript
-- Sam Saccone ([@samccone](https://github.com/samccone)), maintainer of Marionette
-- Simon Boudrias ([@SBoudrias](https://github.com/SBoudrias)), maintainer of Yeoman
-- Sindre Sorhus ([@sindresorhus](https://github.com/sindresorhus)), maintainer of Yeoman
-- Stefan Penner ([@stefanpenner](https://github.com/stefanpenner)), a maintainer of Ember.js
-- Timothy Gu ([@TimothyGu](https://github.com/TimothyGu)), a maintainer of Pug (formerly known as Jade)
-- Trek Glowacki ([@trek](https://github.com/trek)), a maintainer of Ember.js
-- Sashko Stubailo ([@stubailo](https://github.com/stubailo)), a maintainer of Meteor
-- Vlad Filippov ([@vladikoff](https://github.com/vladikoff)), a maintainer of Grunt
-- Graeme Yeates ([@megawac](https://github.com/megawac)), a maintainer of Backbone
-- Chris Rebert ([@cvrebert](https://github.com/cvrebert)), a maintainer of Bootstrap
-- Wesley Cho ([@wesleycho](https://github.com/wesleycho)), a maintainer of UI Bootstrap
-- Zeno Rocha ([@zenorocha](https://github.com/zenorocha)), maintainer of Clipboard.js
-
-[View other signatures](https://docs.google.com/spreadsheets/d/1oGsg02jS-PnlIMJ3OlWIOEmhtG-udTwuDz_vsQPBHKs/edit?usp=sharing)
+[GitHub users](https://docs.google.com/spreadsheets/d/1oGsg02jS-PnlIMJ3OlWIOEmhtG-udTwuDz_vsQPBHKs/edit?usp=sharing)
 
 **Are you the maintainer of a project on GitHub and want to sign as well? [Please sign here](http://goo.gl/forms/DtmQnUXNSE)**


### PR DESCRIPTION
The current signature list in the README is frozen in preference of the Google form. The existing list now comes across as elitist and alienates people who have signed the form as they "aren't good enough" to be on the main list.

The Google spreadsheet now has 500+ signatures and GitHub has responded so I don't think the inclusion of a limited list is required for any influence.