### PR TITLE
Create issue template to redirect people to official GitHub community

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,48 @@
+## Please do not submit issues about GitHub here!
+
+Hi there, thanks for wanting to contribute to this repository.
+Please note that this repository was created in early 2016 for
+the _sole_ purpose of collecting signatures for an open letter
+to GitHub regarding a small number of specific issues with their
+service.
+
+The signatures were collected, and GitHub replied, as you can see
+[below the original letter](https://github.com/dear-github/dear-github/blob/master/README.md).
+Therefore this repository successfully served its purpose.
+
+### Reporting other issues about GitHub
+
+Unfortunately GitHub do not offer a public issue tracker in which
+to report problems / suggestions regarding their service.  Therefore
+if you want to do this, the following process is recommended:
+
+1. Check https://github.com/isaacs/github/issues to see if your
+   issue has already been reported there.  https://github.com/isaacs/github
+   was started in 2013 precisely [to fill the void left by GitHub's
+   decision not to provide their own issue tracker](https://github.com/isaacs/github/issues/6),
+   and it's the most popular initiative of its kind, therefore
+   it makes sense for the GitHub community to pool efforts there.
+
+2. If your issue has not already been reported there, 
+   [file it!](https://github.com/isaacs/github/issues/new)
+
+3. Finally, copy the same text into [GitHub's official support 
+   request form](https://github.com/contact), and also paste
+   the URL linking to the issue you filed in step 2, along with
+   a reminder to GitHub that it would really help their community
+   if they offered a public issue tracker for their service.
+   (Presumably the more people that tell them this, the more
+   likely they are to heed the advice.)
+   
+### GitHub Community Forum
+
+To be fair to GitHub, [in November 2017](https://blog.github.com/2017-11-01-connect-with-developers-around-the-world-on-the-github-community-forum/)
+they did introduce the [GitHub Community Forum](https://github.community/)
+which is arguably a step in the right direction, and you may decide
+that you prefer to discuss your topic there rather than following
+the recommended procedure above.
+
+However forums are designed for more conversational usage, and are typically
+no substitute for the structured approach to issue tracking which is offered
+by GitHub's own issue tracker and [many other popular
+solutions](https://alternativeto.net/software/redmine/).


### PR DESCRIPTION
**UPDATE:** since https://github.com/isaacs/github was (wrongly, IMHO) archived, there is [an official GitHub community discussion forum](https://github.com/community), so dear-github should redirect to that now.

Original text below:

-------

This repository was created for a specific purpose, which was fulfilled back in 2016.  However people are still submitting issues about GitHub to the repository's issue tracker.  This effectively fragments and weakens the GitHub community, because https://github.com/isaacs/github was already established in 2013 [for the same purpose](https://github.com/isaacs/github/issues/6), and has acquired very significant momentum since then.  It is more efficient for the community to pool its efforts in a single place, so make an issue template which explains the current situation and encourages people to submit issues to isaacs instead of here.

This partially addresses #207.  When combined with a PR auto-closer bot as suggested in https://github.com/isaacs/github/issues/1191, the combination could be considered as a full solution for #207.